### PR TITLE
chore: increase timeout for hermes relayer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Check if Hermes relayer has started
         run: |
-          timeout 240 bash -c "\
+          timeout 420 bash -c "\
           until docker logs relayer 2>&1 | grep -q 'Hermes has started'; do
             echo 'waiting for relayer to start...'
           done"


### PR DESCRIPTION
In #1, we are making a change that requires waiting for the chains to start. As a result, the step in the CI pipeline that waits for the Hermes relayer is affected. Increasing the timeout will resolve this issue.